### PR TITLE
[Android] Fix not correct section offset calculation

### DIFF
--- a/FlexiMvvm.Collections/Platform.Android/Collections/Core/ItemsMapping.cs
+++ b/FlexiMvvm.Collections/Platform.Android/Collections/Core/ItemsMapping.cs
@@ -107,7 +107,7 @@ namespace FlexiMvvm.Collections.Core
 
             while (i < section)
             {
-                if (ItemsMap[++offset].ItemKind == ItemKind.SectionFooter)
+                if (ItemsMap[offset++].ItemKind == ItemKind.SectionFooter)
                 {
                     i++;
                 }


### PR DESCRIPTION
At _GroupAdapter_ first section footer was at the end of ItemMap list (N-1, before empty footer), so because of this, there are some mess with updating _GroupAdapter_ collection at runtime