### PR TITLE
[Android] GetSectionsLength Fix

### DIFF
--- a/FlexiMvvm.Collections/Platform.Android/Collections/Core/GroupedItemsMapping.cs
+++ b/FlexiMvvm.Collections/Platform.Android/Collections/Core/GroupedItemsMapping.cs
@@ -111,7 +111,7 @@ namespace FlexiMvvm.Collections.Core
 
             foreach (IGrouping<object, object> itemsGroup in groupedItems)
             {
-                length += SectionHeaderCount + itemsGroup?.Count() ?? 0 + SectionFooterCount;
+                length += SectionHeaderCount + (itemsGroup?.Count() ?? 0) + SectionFooterCount;
             }
 
             return length;


### PR DESCRIPTION
To explain this issue, there is a code, how it looks like in non-fixed version

```
{
     length += SectionHeaderCount;

     if (itemsGroup == null)
     {
          length += 0 + SectionFooterCount;
     }
     else
     {
          length += itemsGroup.Count();
     }
}
```